### PR TITLE
unbundle: place git-location.json and localized-values.yaml inside chart dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -285,7 +285,7 @@ func unbundle(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not marshal localized-values.yaml: %w", err)
 	}
-	localizedValuesPath := filepath.Join(outputDirPath, "localized-values.yaml")
+	localizedValuesPath := filepath.Join(chartPath, "localized-values.yaml")
 	err = os.WriteFile(localizedValuesPath, buf, 0666) // NOTE: final mode is subject to umask
 	if err != nil {
 		return err
@@ -296,7 +296,7 @@ func unbundle(cmd *cobra.Command, args []string) error {
 	if ok {
 		gitLocationJSON, ok := gitLocationValue.(string)
 		if ok {
-			gitLocationPath := filepath.Join(outputDirPath, "git-location.json")
+			gitLocationPath := filepath.Join(chartPath, "git-location.json")
 			err = os.WriteFile(gitLocationPath, []byte(gitLocationJSON), 0666) // NOTE: final mode is subject to umask
 			if err != nil {
 				return err


### PR DESCRIPTION
Once we add support for bundling multiple charts, putting them in the toplevel next to the chart would not work because we have multiple such files to place. Putting them inside the chart makes the paths for the different files sufficiently unique.

This will break the existing CI because it refers to the `localized-values.yaml`, so a PR for the pipeline definition will follow.